### PR TITLE
Support communicating with the bot using mentions

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -2,9 +2,8 @@ export default {
   // *Required* Prefix for commands.
   PREFIX: '!',
 
-  // *Required* Discord email username, and password for your bot.
+  // *Required* Discord email and password for your bot.
   EMAIL: '',
-  USERNAME: '',
   PASSWORD: '',
 
   // Youtube API key to be used when searching youtube videos.

--- a/config.js.example
+++ b/config.js.example
@@ -2,8 +2,9 @@ export default {
   // *Required* Prefix for commands.
   PREFIX: '!',
 
-  // *Required* Discord email and password for your bot.
+  // *Required* Discord email username, and password for your bot.
   EMAIL: '',
+  USERNAME: '',
   PASSWORD: '',
 
   // Youtube API key to be used when searching youtube videos.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import { Client as Discord } from 'discord.js';
 import express from 'express';
 import nconf from 'nconf';
+import R from 'ramda';
 
 import './lib/config/init';
 import commands from './lib';
@@ -25,13 +26,24 @@ bot.on('disconnected', () => {
 });
 
 bot.on('message', msg => {
-  // Checks if the message is a command
+  // Checks for PREFIX
   if (msg.content[0] === nconf.get('PREFIX')) {
     let command = msg.content.toLowerCase().split(' ')[0].substring(1);
     let suffix = msg.content.substring(command.length + 2);
     let cmd = commands[command];
 
     if (cmd) cmd(bot, msg, suffix);
+    return;
+  }
+
+  // Checks if bot was mentioned
+  if (msg.mentions.get('username', nconf.get('USERNAME'))) {
+    let msg_split = msg.content.split(' ');
+    let suffix = R.join(' ', R.slice(2, msg_split.length, msg_split));
+    let cmd = commands[msg_split[1]];
+
+    if (cmd) cmd(bot, msg, suffix);
+    return;
   }
 });
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ bot.on('message', msg => {
   }
 
   // Checks if bot was mentioned
-  if (msg.mentions.get('username', nconf.get('USERNAME'))) {
+  if (msg.isMentioned(bot.user)) {
     let msg_split = msg.content.split(' ');
     let suffix = R.join(' ', R.slice(2, msg_split.length, msg_split));
     let cmd = commands[msg_split[1]];

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { Client as Discord } from 'discord.js';
+import { Client as Discord, PMChannel } from 'discord.js';
 import express from 'express';
 import nconf from 'nconf';
 import R from 'ramda';
@@ -41,6 +41,16 @@ bot.on('message', msg => {
     let msg_split = msg.content.split(' ');
     let suffix = R.join(' ', R.slice(2, msg_split.length, msg_split));
     let cmd = commands[msg_split[1]];
+
+    if (cmd) cmd(bot, msg, suffix);
+    return;
+  }
+
+  // Check personal messages
+  if (msg.channel instanceof PMChannel) {
+    let msg_split = msg.content.split(' ');
+    let suffix = R.join(' ', R.slice(1, msg_split.length, msg_split));
+    let cmd = commands[msg_split[0]];
 
     if (cmd) cmd(bot, msg, suffix);
     return;


### PR DESCRIPTION
## Overview

Adds support for communicating with Gravebot using mentions. This keeps checking each message performant as it only parse `msg.content` if discords mentions cache contains the bots username, instead of string comparison or splitting the message in to an array right away.

Fixes https://github.com/Gravestorm/Gravebot/issues/17