### PR TITLE
Appear.in

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ For self hosting, click [here](#localconfig).
 - `!wiki` *search terms* - Returns the summary of the first matching search result from Wikipedia
 - `!youtube` *video tags* - Gets a video from Youtube matching the given tags
 - `!wolfram` *query* - Query Wolfram Alpha for almost anything
+- `!videocall` - Start a one click video call or screenshare directly on Appear.in
 
 #### Information:
 - `!avatar` *@username* - Responds with the avatar of the user, if no user is written, the avatar of the sender

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For self hosting, click [here](#localconfig).
 - `!wiki` *search terms* - Returns the summary of the first matching search result from Wikipedia
 - `!youtube` *video tags* - Gets a video from Youtube matching the given tags
 - `!wolfram` *query* - Query Wolfram Alpha for almost anything
-- `!videocall` - Start a one click video call or screenshare directly on Appear.in
+- `!videocall` *__Optional__ @username* - Start a one click video call or screenshare directly on Appear.in. Mention users to make it private.
 
 #### Information:
 - `!avatar` *@username* - Responds with the avatar of the user, if no user is written, the avatar of the sender

--- a/lib/appearin.js
+++ b/lib/appearin.js
@@ -1,6 +1,16 @@
+import R from 'ramda';
+
+
 function appearin(bot, msg) {
   let id = Math.random().toString().replace('.', '').slice(0, 10);
-  bot.sendMessage(msg.channel, `https://appear.in/${id}`);
+  let url = `https://appear.in/${id}`;
+
+  // If no mentions, send link back to channel.
+  if (!msg.mentions.length) return bot.sendMessage(msg.channel, url);
+
+  // Send url back to author and mentioend users
+  bot.sendMessage(msg.author, url);
+  R.forEach(user => bot.sendMessage(user, `${msg.author.name} would like you to join a videocall/screenshare. ${url}`), msg.mentions);
 }
 
 export default {

--- a/lib/appearin.js
+++ b/lib/appearin.js
@@ -1,0 +1,10 @@
+function appearin(bot, msg) {
+  let id = Math.random().toString().replace('.', '').slice(0, 10);
+  bot.sendMessage(msg.channel, `https://appear.in/${id}`);
+}
+
+export default {
+  appearin,
+  ss: appearin,
+  videocall: appearin
+};

--- a/lib/help/english.js
+++ b/lib/help/english.js
@@ -48,7 +48,9 @@ export default {
 **\`!yt\`** \`video tags\`
 		Gets a video from Youtube matching the given tags
 **\`!wolfram\`** \`query\`
-		Query Wolfram Alpha for almost anything`,
+		Query Wolfram Alpha for almost anything
+**\`!videocall\`**
+    Start a one click video call or screenshare directly on Appear.in`,
   info: `**\`!avatar\`** \`@username\`
 		Responds with the Avatar of the user, if no user is written, your avatar
 **\`!serverinfo\`**

--- a/lib/help/english.js
+++ b/lib/help/english.js
@@ -50,7 +50,7 @@ export default {
 **\`!wolfram\`** \`query\`
 		Query Wolfram Alpha for almost anything
 **\`!videocall\`**
-    Start a one click video call or screenshare directly on Appear.in`,
+    Start a one click video call or screenshare directly on Appear.in. Mention users to make it private.`,
   info: `**\`!avatar\`** \`@username\`
 		Responds with the Avatar of the user, if no user is written, your avatar
 **\`!serverinfo\`**

--- a/lib/help/french.js
+++ b/lib/help/french.js
@@ -46,7 +46,9 @@ export default {
 **\`!yt\`** \`tags de la vidéo\`
     Retourne la vidéo youtube correspondant aux tags
 **\`!wolfram\`** \`requête\`
-    Consulta Wolfram Alpha para obtener información`,
+    Consulta Wolfram Alpha para obtener información
+**\`!videocall\`**
+    Démarrer un appel vidéo d'un clic ou ScreenShare directement sur Appear.in`,
   info: `**\`!avatar\`** \`@username\`
 		Retourne l'avatar de l'utilisateur, si aucun noms d'utilisateur est spécifié, votre avatar
 **\`!serverinfo\`**

--- a/lib/help/french.js
+++ b/lib/help/french.js
@@ -48,7 +48,8 @@ export default {
 **\`!wolfram\`** \`requête\`
     Consulta Wolfram Alpha para obtener información
 **\`!videocall\`**
-    Démarrer un appel vidéo d'un clic ou ScreenShare directement sur Appear.in`,
+    Démarrer un appel vidéo d'un clic ou ScreenShare directement sur Appear.in.
+Mention utilisateurs pour le rendre privé.`,
   info: `**\`!avatar\`** \`@username\`
 		Retourne l'avatar de l'utilisateur, si aucun noms d'utilisateur est spécifié, votre avatar
 **\`!serverinfo\`**

--- a/tests/appearin.js
+++ b/tests/appearin.js
@@ -3,21 +3,52 @@ import sinon from 'sinon';
 
 import appearin from '../lib/appearin';
 
+let sandbox;
 chai.should();
 
-describe('appearin', () => {
-  it('should return a description for the roll', done => {
-    const sandbox = sinon.sandbox.create();
-    sandbox.stub(Math, 'random', () => 0.234342344890234089234089);
 
+describe('appearin', () => {
+  before(() => {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(Math, 'random', () => 0.234342344890234089234089);
+  });
+
+  after(() => sandbox.restore());
+
+  it('should return a appearin URL to the channel', done => {
     function sendMessage(channel, res) {
       channel.should.equal('test');
       res.should.equal('https://appear.in/0234342344');
-
-      sandbox.restore();
       done();
     }
 
-    appearin.appearin({sendMessage}, {channel: 'test'});
+    appearin.appearin({sendMessage}, {channel: 'test', mentions: []});
+  });
+
+  it('should return a appearin url to the author and mentioned users in PMs', done => {
+    let msg = {
+      channel: 'test',
+      mentions: [{name: 'usertest'}],
+      author: {
+        name: 'authortest'
+      }
+    };
+
+    let testcount = 0;
+
+    function sendMessage(channel, res) {
+      testcount++;
+      if (testcount === 1) {
+        channel.should.equal(msg.author);
+        res.should.equal('https://appear.in/0234342344');
+      } else {
+        channel.should.equal(msg.mentions[0]);
+        res.should.equal('authortest would like you to join a videocall/screenshare. https://appear.in/0234342344');
+      }
+
+      if (testcount === 2) done();
+    }
+
+    appearin.appearin({sendMessage}, msg);
   });
 });

--- a/tests/appearin.js
+++ b/tests/appearin.js
@@ -1,0 +1,23 @@
+import chai from 'chai';
+import sinon from 'sinon';
+
+import appearin from '../lib/appearin';
+
+chai.should();
+
+describe('appearin', () => {
+  it('should return a description for the roll', done => {
+    const sandbox = sinon.sandbox.create();
+    sandbox.stub(Math, 'random', () => 0.234342344890234089234089);
+
+    function sendMessage(channel, res) {
+      channel.should.equal('test');
+      res.should.equal('https://appear.in/0234342344');
+
+      sandbox.restore();
+      done();
+    }
+
+    appearin.appearin({sendMessage}, {channel: 'test'});
+  });
+});


### PR DESCRIPTION
## Overview

Create a random appear.in video call. This allows users to start a video chat or screenshare with one command, one click. Alias' include `!ss` and `!appearin`.

Fixes #76 

<img width="781" alt="screen shot 2016-01-09 at 5 44 24 pm" src="https://cloud.githubusercontent.com/assets/5246169/12218837/d75aa8a2-b6f8-11e5-9cff-a726cef05850.png">
