### PR TITLE
Added Pastebin command

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -32,5 +32,9 @@ export default {
 
   // Wolfram Alpha. Ask it anything.
   // http://products.wolframalpha.com/developers/
-  WOLFRAM_KEY: ''
+  WOLFRAM_KEY: '',
+
+  //PasteBin Api Key
+  // http://pastebin.com/api/
+  PASTEBIN_KEY: ''
 };

--- a/lib/help/english.js
+++ b/lib/help/english.js
@@ -54,7 +54,9 @@ export default {
 **\`!wolfram\`** \`query\`
 		Query Wolfram Alpha for almost anything
 **\`!videocall\`**
-    Start a one click video call or screenshare directly on Appear.in. Mention users to make it private.`,
+    Start a one click video call or screenshare directly on Appear.in. Mention users to make it private.
+**\`!paste\`**\`text\`
+    Creates a paste on Pastebin.com and returns the url`,
   info: `**\`!avatar\`** \`@username\`
 		Responds with the Avatar of the user, if no user is written, your avatar
 **\`!serverinfo\`**

--- a/lib/help/english.js
+++ b/lib/help/english.js
@@ -45,6 +45,8 @@ export default {
 		Gets a gif from Giphy matching the given tags
 **\`!join\`** \`invitation link\`
 		Joins the server the bot is invited to
+**\`!paste\`**\`text\`
+    Creates a paste on Pastebin.com and returns the url
 **\`!urban\`** \`search terms\`
 		Returns the summary of the first matching search result from Urban Dictionary
 **\`!wiki\`** \`search terms\`
@@ -54,9 +56,7 @@ export default {
 **\`!wolfram\`** \`query\`
 		Query Wolfram Alpha for almost anything
 **\`!videocall\`**
-    Start a one click video call or screenshare directly on Appear.in. Mention users to make it private.
-**\`!paste\`**\`text\`
-    Creates a paste on Pastebin.com and returns the url`,
+    Start a one click video call or screenshare directly on Appear.in. Mention users to make it private.`,
   info: `**\`!avatar\`** \`@username\`
 		Responds with the Avatar of the user, if no user is written, your avatar
 **\`!serverinfo\`**

--- a/lib/pastebin.js
+++ b/lib/pastebin.js
@@ -2,6 +2,7 @@ import Promise from 'bluebird';
 import nconf from 'nconf';
 import R from 'ramda';
 import _request from 'request';
+import sentry from './config/sentry';
 
 const request = Promise.promisify(_request);
 
@@ -17,13 +18,16 @@ function makePaste(bot, msg, paste) {
   };
 
   request(options)
-  .then(R.prop('body'))
-  .then(text => bot.sendMessage(msg.channel, text))
-  .done();
+    .then(R.prop('body'))
+    .then(text => bot.sendMessage(msg.channel, text))
+    .catch(err => {
+      sentry.captureError(err);
+      bot.sendMessage(msg.channel, `Error: ${err.message}`);
+    });
 }
 
 export default {
   paste: makePaste,
   pastebin: makePaste,
-  makePaste: makePaste
+  makepaste: makePaste
 };

--- a/lib/pastebin.js
+++ b/lib/pastebin.js
@@ -1,0 +1,30 @@
+import Promise from 'bluebird';
+import nconf from 'nconf';
+import R from 'ramda';
+import _request from 'request';
+
+const request = Promise.promisify(_request);
+
+function makePaste(bot, msg, paste) {
+
+  let options = {
+    url: 'http://pastebin.com/api/api_post.php',
+    method: 'POST',
+    form: {
+      api_option: 'paste',
+      api_paste_code: paste,
+      api_dev_key: nconf.get('PASTEBIN_KEY')
+    }
+  };
+
+request(options)
+  .then(R.prop('body'))
+  .then(text => bot.sendMessage(msg.channel, text))
+  .done();
+}
+
+export default {
+  paste: makePaste,
+  pastebin: makePaste,
+  makePaste: makePaste
+};

--- a/lib/pastebin.js
+++ b/lib/pastebin.js
@@ -6,7 +6,6 @@ import _request from 'request';
 const request = Promise.promisify(_request);
 
 function makePaste(bot, msg, paste) {
-
   let options = {
     url: 'http://pastebin.com/api/api_post.php',
     method: 'POST',
@@ -17,7 +16,7 @@ function makePaste(bot, msg, paste) {
     }
   };
 
-request(options)
+  request(options)
   .then(R.prop('body'))
   .then(text => bot.sendMessage(msg.channel, text))
   .done();

--- a/tests/pastebin.js
+++ b/tests/pastebin.js
@@ -1,0 +1,26 @@
+import chai from 'chai';
+import fs from 'fs';
+import nconf from 'nconf';
+import nock from 'nock';
+import pastebin from '../lib/pastebin';
+
+chai.should();
+
+describe('pastebin', () => {
+    const key = nconf.get('PASTEBIN_KEY');
+
+  it('should return a url to a paste', done => {
+    function sendMessage(channel, res) {
+      channel.should.equal('test');
+      res.should.equal('http://pastebin.com/EcYgmBpk');
+      done();
+    }
+
+    nock.cleanAll();
+    nock('http://pastebin.com')
+      .post('/api/api_post.php', {api_dev_key: key, api_option: 'paste', api_paste_code: 'test'})
+      .reply(200, 'http://pastebin.com/EcYgmBpk');
+
+      pastebin.makePaste({sendMessage}, {channel: 'test'}, 'test');
+  });
+});

--- a/tests/pastebin.js
+++ b/tests/pastebin.js
@@ -1,5 +1,4 @@
 import chai from 'chai';
-import fs from 'fs';
 import nconf from 'nconf';
 import nock from 'nock';
 import pastebin from '../lib/pastebin';
@@ -7,7 +6,7 @@ import pastebin from '../lib/pastebin';
 chai.should();
 
 describe('pastebin', () => {
-    const key = nconf.get('PASTEBIN_KEY');
+  const key = nconf.get('PASTEBIN_KEY');
 
   it('should return a url to a paste', done => {
     function sendMessage(channel, res) {
@@ -21,6 +20,6 @@ describe('pastebin', () => {
       .post('/api/api_post.php', {api_dev_key: key, api_option: 'paste', api_paste_code: 'test'})
       .reply(200, 'http://pastebin.com/EcYgmBpk');
 
-      pastebin.makePaste({sendMessage}, {channel: 'test'}, 'test');
+    pastebin.makePaste({sendMessage}, {channel: 'test'}, 'test');
   });
 });

--- a/tests/pastebin.js
+++ b/tests/pastebin.js
@@ -20,6 +20,6 @@ describe('pastebin', () => {
       .post('/api/api_post.php', {api_dev_key: key, api_option: 'paste', api_paste_code: 'test'})
       .reply(200, 'http://pastebin.com/EcYgmBpk');
 
-    pastebin.makePaste({sendMessage}, {channel: 'test'}, 'test');
+    pastebin.paste({sendMessage}, {channel: 'test'}, 'test');
   });
 });


### PR DESCRIPTION
## Overview

This was a feature mentioned under "Issues" that I wanted to give a shot. Wasn't marked "help wanted" so if you don't want to use it, it's fine. 

This uses the Pastebin Api (developer api key must be set in config.js) to allow users to create Pastebin pastes using a "!paste {text}" command and returns a url to their paste. I did my best to stick to ES6 and the procedures set up in other commands.

It passes the test I made, but this was my first encounter with Nock, so it should be double-checked. I used the other test files as a template. 

Also added command info under the English "help" section.

## Screenshots

![Screenshot 1]
(https://i.gyazo.com/a6771d8c9f966dd1b9a0f628af074a3d.png)

![Screenshot 2]
(https://i.gyazo.com/740d319222fccec520e22cb60fe15314.png)